### PR TITLE
스케줄러를 활용해 분당 CPU 사용량 측정 기능 구현 완료

### DIFF
--- a/src/main/java/terra/backend/common/config/SchedulerConfig.java
+++ b/src/main/java/terra/backend/common/config/SchedulerConfig.java
@@ -1,0 +1,8 @@
+package terra.backend.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {}

--- a/src/main/java/terra/backend/common/utils/DateUtils.java
+++ b/src/main/java/terra/backend/common/utils/DateUtils.java
@@ -1,0 +1,14 @@
+package terra.backend.common.utils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public abstract class DateUtils {
+
+  private DateUtils() {}
+
+  public static LocalDateTime getCustomHour(int hour) {
+    return LocalDateTime.of(LocalDate.now(), LocalTime.of(hour, 0, 0));
+  }
+}

--- a/src/main/java/terra/backend/common/utils/IntSummaryStatisticsUtils.java
+++ b/src/main/java/terra/backend/common/utils/IntSummaryStatisticsUtils.java
@@ -1,0 +1,27 @@
+package terra.backend.common.utils;
+
+import java.util.IntSummaryStatistics;
+import java.util.List;
+import terra.backend.domain.cpu.entity.CpuHourlyUsage;
+
+public abstract class IntSummaryStatisticsUtils {
+
+  private IntSummaryStatisticsUtils() {}
+
+  public static IntSummaryStatistics of(List<CpuHourlyUsage> list) {
+    int max = Integer.MIN_VALUE;
+    int min = Integer.MAX_VALUE;
+    int totalUsage = 0;
+    int totalCount = 0;
+
+    for (CpuHourlyUsage usage : list) {
+      max = Math.max(usage.getMaxUsage(), max);
+      min = Math.min(usage.getMinUsage(), min);
+
+      totalUsage += usage.getTotalUsage();
+      totalCount += usage.getSamplingCount();
+    }
+
+    return new IntSummaryStatistics(totalCount, min, max, totalUsage);
+  }
+}

--- a/src/main/java/terra/backend/domain/cpu/cache/CpuCache.java
+++ b/src/main/java/terra/backend/domain/cpu/cache/CpuCache.java
@@ -1,0 +1,13 @@
+package terra.backend.domain.cpu.cache;
+
+import java.util.List;
+import terra.backend.domain.cpu.cache.dto.CpuUsage;
+import terra.backend.domain.cpu.entity.CpuMinuteUsage;
+
+public interface CpuCache {
+  void save(CpuMinuteUsage entity);
+
+  void clear();
+
+  List<CpuUsage> getCpuUsageList();
+}

--- a/src/main/java/terra/backend/domain/cpu/cache/CpuCacheImpl.java
+++ b/src/main/java/terra/backend/domain/cpu/cache/CpuCacheImpl.java
@@ -1,0 +1,30 @@
+package terra.backend.domain.cpu.cache;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+import terra.backend.domain.cpu.cache.dto.CpuUsage;
+import terra.backend.domain.cpu.entity.CpuMinuteUsage;
+
+@Component
+public class CpuCacheImpl implements CpuCache {
+  private static Map<LocalDateTime, Integer> map = new HashMap<>();
+
+  public void save(CpuMinuteUsage entity) {
+    map.put(entity.getSamplingDate(), entity.getUsage());
+  }
+
+  @Override
+  public void clear() {
+    map.clear();
+  }
+
+  @Override
+  public List<CpuUsage> getCpuUsageList() {
+    return map.entrySet().stream()
+        .map(entry -> new CpuUsage(entry.getValue(), entry.getKey()))
+        .toList();
+  }
+}

--- a/src/main/java/terra/backend/domain/cpu/cache/dto/CpuUsage.java
+++ b/src/main/java/terra/backend/domain/cpu/cache/dto/CpuUsage.java
@@ -1,0 +1,21 @@
+package terra.backend.domain.cpu.cache.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CpuUsage {
+  private int usage;
+  private LocalDateTime samplingDate;
+
+  public CpuUsage(int usage, LocalDateTime samplingDate) {
+    this.usage = usage;
+    this.samplingDate = samplingDate;
+  }
+
+  public int getHour() {
+    return samplingDate.getHour();
+  }
+}

--- a/src/main/java/terra/backend/domain/cpu/entity/CpuDailyUsage.java
+++ b/src/main/java/terra/backend/domain/cpu/entity/CpuDailyUsage.java
@@ -33,7 +33,7 @@ public class CpuDailyUsage {
   public CpuDailyUsage(int maxUsage, int minUsage, double avgUsage, LocalDate samplingDate) {
     this.maxUsage = maxUsage;
     this.minUsage = minUsage;
-    this.avgUsage = String.valueOf(avgUsage);
+    this.avgUsage = String.valueOf(Math.round(avgUsage));
     this.samplingDate = samplingDate;
   }
 }

--- a/src/main/java/terra/backend/domain/cpu/entity/CpuDailyUsage.java
+++ b/src/main/java/terra/backend/domain/cpu/entity/CpuDailyUsage.java
@@ -5,7 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,8 +25,15 @@ public class CpuDailyUsage {
   private int minUsage;
 
   @Column(nullable = false)
-  private int avgUsage;
+  private String avgUsage;
 
   @Column(nullable = false)
-  private LocalDateTime samplingDate;
+  private LocalDate samplingDate;
+
+  public CpuDailyUsage(int maxUsage, int minUsage, double avgUsage, LocalDate samplingDate) {
+    this.maxUsage = maxUsage;
+    this.minUsage = minUsage;
+    this.avgUsage = String.valueOf(avgUsage);
+    this.samplingDate = samplingDate;
+  }
 }

--- a/src/main/java/terra/backend/domain/cpu/entity/CpuHourlyUsage.java
+++ b/src/main/java/terra/backend/domain/cpu/entity/CpuHourlyUsage.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
+import java.util.IntSummaryStatistics;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,8 +26,37 @@ public class CpuHourlyUsage {
   private int minUsage;
 
   @Column(nullable = false)
-  private int avgUsage;
+  private String avgUsage;
+
+  @Column(nullable = false)
+  private int totalUsage;
+
+  private int samplingCount;
 
   @Column(nullable = false)
   private LocalDateTime samplingDate;
+
+  public CpuHourlyUsage(
+      int maxUsage,
+      int minUsage,
+      double avgUsage,
+      int totalUsage,
+      int samplingCount,
+      LocalDateTime samplingDate) {
+    this.maxUsage = maxUsage;
+    this.minUsage = minUsage;
+    this.avgUsage = String.valueOf(Math.round(avgUsage));
+    this.samplingCount = samplingCount;
+    this.totalUsage = totalUsage;
+    this.samplingDate = samplingDate;
+  }
+
+  public CpuHourlyUsage(IntSummaryStatistics summary, LocalDateTime samplingDate) {
+    this.maxUsage = summary.getMax();
+    this.minUsage = summary.getMin();
+    this.avgUsage = String.valueOf(Math.round(summary.getAverage()));
+    this.samplingCount = (int) summary.getCount();
+    this.totalUsage = (int) summary.getSum();
+    this.samplingDate = samplingDate;
+  }
 }

--- a/src/main/java/terra/backend/domain/cpu/entity/CpuMinuteUsage.java
+++ b/src/main/java/terra/backend/domain/cpu/entity/CpuMinuteUsage.java
@@ -35,4 +35,9 @@ public class CpuMinuteUsage {
     this.usage = usage;
     this.samplingDate = LocalDateTime.now();
   }
+
+  public CpuMinuteUsage(int usage, LocalDateTime samplingDate) {
+    this.usage = usage;
+    this.samplingDate = samplingDate;
+  }
 }

--- a/src/main/java/terra/backend/domain/cpu/entity/CpuMinuteUsage.java
+++ b/src/main/java/terra/backend/domain/cpu/entity/CpuMinuteUsage.java
@@ -23,4 +23,8 @@ public class CpuMinuteUsage {
 
   @Column(nullable = false)
   private LocalDateTime samplingDate;
+
+  public CpuMinuteUsage(int cpuLoad) {
+    this.usage = cpuLoad;
+  }
 }

--- a/src/main/java/terra/backend/domain/cpu/entity/CpuMinuteUsage.java
+++ b/src/main/java/terra/backend/domain/cpu/entity/CpuMinuteUsage.java
@@ -6,12 +6,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CpuMinuteUsage {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,5 +27,12 @@ public class CpuMinuteUsage {
 
   public CpuMinuteUsage(int cpuLoad) {
     this.usage = cpuLoad;
+    this.samplingDate = LocalDateTime.now();
+  }
+
+  public CpuMinuteUsage(Long id, int usage) {
+    this.id = id;
+    this.usage = usage;
+    this.samplingDate = LocalDateTime.now();
   }
 }

--- a/src/main/java/terra/backend/domain/cpu/exception/CpuExceptionCode.java
+++ b/src/main/java/terra/backend/domain/cpu/exception/CpuExceptionCode.java
@@ -1,0 +1,15 @@
+package terra.backend.domain.cpu.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import terra.backend.common.exception.exception.enums.ExceptionCode;
+
+@Getter
+@AllArgsConstructor
+public enum CpuExceptionCode implements ExceptionCode {
+  NOT_FOUND(HttpStatus.NOT_FOUND, "사용량을 조회할 수 없습니다.");
+  HttpStatus httpStatus;
+
+  String message;
+}

--- a/src/main/java/terra/backend/domain/cpu/init/InitCache.java
+++ b/src/main/java/terra/backend/domain/cpu/init/InitCache.java
@@ -1,0 +1,29 @@
+package terra.backend.domain.cpu.init;
+
+import jakarta.annotation.PostConstruct;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import terra.backend.domain.cpu.cache.CpuCache;
+import terra.backend.domain.cpu.entity.CpuMinuteUsage;
+import terra.backend.domain.cpu.repository.MinuteUsageRepository;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class InitCache {
+  private final MinuteUsageRepository repository;
+  private final CpuCache cache;
+
+  @PostConstruct
+  public void uploadToCache() {
+    LocalDateTime now = LocalDateTime.of(LocalDate.now(), LocalTime.of(0, 0));
+
+    List<CpuMinuteUsage> todayUsage = repository.findTodayUsage(now);
+    todayUsage.forEach(cache::save);
+  }
+}

--- a/src/main/java/terra/backend/domain/cpu/repository/DailyUsageRepository.java
+++ b/src/main/java/terra/backend/domain/cpu/repository/DailyUsageRepository.java
@@ -1,0 +1,6 @@
+package terra.backend.domain.cpu.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import terra.backend.domain.cpu.entity.CpuDailyUsage;
+
+public interface DailyUsageRepository extends JpaRepository<CpuDailyUsage, Long> {}

--- a/src/main/java/terra/backend/domain/cpu/repository/HourlyUsageRepository.java
+++ b/src/main/java/terra/backend/domain/cpu/repository/HourlyUsageRepository.java
@@ -1,0 +1,6 @@
+package terra.backend.domain.cpu.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import terra.backend.domain.cpu.entity.CpuHourlyUsage;
+
+public interface HourlyUsageRepository extends JpaRepository<CpuHourlyUsage, Long> {}

--- a/src/main/java/terra/backend/domain/cpu/repository/MinuteUsageRepository.java
+++ b/src/main/java/terra/backend/domain/cpu/repository/MinuteUsageRepository.java
@@ -1,0 +1,6 @@
+package terra.backend.domain.cpu.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import terra.backend.domain.cpu.entity.CpuMinuteUsage;
+
+public interface MinuteUsageRepository extends JpaRepository<CpuMinuteUsage, Long> {}

--- a/src/main/java/terra/backend/domain/cpu/repository/MinuteUsageRepository.java
+++ b/src/main/java/terra/backend/domain/cpu/repository/MinuteUsageRepository.java
@@ -1,6 +1,14 @@
 package terra.backend.domain.cpu.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import terra.backend.domain.cpu.entity.CpuMinuteUsage;
 
-public interface MinuteUsageRepository extends JpaRepository<CpuMinuteUsage, Long> {}
+public interface MinuteUsageRepository extends JpaRepository<CpuMinuteUsage, Long> {
+
+  @Query("SELECT c FROM CpuMinuteUsage c WHERE c.samplingDate > :startDate ")
+  List<CpuMinuteUsage> findTodayUsage(@Param("startDate") LocalDateTime startDate);
+}

--- a/src/main/java/terra/backend/domain/cpu/scheduler/CpuSaveScheduler.java
+++ b/src/main/java/terra/backend/domain/cpu/scheduler/CpuSaveScheduler.java
@@ -1,0 +1,50 @@
+package terra.backend.domain.cpu.scheduler;
+
+import com.sun.management.OperatingSystemMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import terra.backend.domain.cpu.cache.CpuCache;
+import terra.backend.domain.cpu.cache.dto.CpuUsage;
+import terra.backend.domain.cpu.entity.CpuHourlyUsage;
+import terra.backend.domain.cpu.entity.CpuMinuteUsage;
+import terra.backend.domain.cpu.service.CpuService;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CpuSaveScheduler {
+  private final CpuService service;
+  private final CpuCache cache;
+
+  @Scheduled(cron = "0 * * * * *")
+  public void saveCpuUsagePerMinute() {
+    OperatingSystemMXBean osBean = ManagementFactory.getPlatformMXBean(OperatingSystemMXBean.class);
+
+    // return 0 since we have no data, not -1 which indicates error
+    double cpuLoad = osBean.getCpuLoad() * 100;
+
+    // save Data in RDB
+    CpuMinuteUsage entity = service.saveMinuteUsage((int) cpuLoad);
+
+    // save Data in Cache
+    cache.save(entity);
+  }
+
+  @Scheduled(cron = "30 59 23 * * *")
+  public void saveDailyAndHourlyUsage() {
+    List<CpuUsage> todayCacheUsage = cache.getCpuUsageList();
+
+    // 시간별 CPU 사용량
+    List<CpuHourlyUsage> cpuHourlyUsages = service.saveHourlyUsage(todayCacheUsage);
+
+    // 하루 CPU 사용량
+    service.saveDailyUsage(cpuHourlyUsages);
+
+    // 캐쉬 초기화
+    cache.clear();
+  }
+}

--- a/src/main/java/terra/backend/domain/cpu/service/CpuService.java
+++ b/src/main/java/terra/backend/domain/cpu/service/CpuService.java
@@ -7,7 +7,7 @@ import terra.backend.domain.cpu.entity.CpuHourlyUsage;
 import terra.backend.domain.cpu.entity.CpuMinuteUsage;
 
 public interface CpuService {
-  CpuMinuteUsage save(int cpuLoad);
+  CpuMinuteUsage saveMinuteUsage(int cpuLoad);
 
   List<CpuHourlyUsage> saveHourlyUsage(List<CpuUsage> list);
 

--- a/src/main/java/terra/backend/domain/cpu/service/CpuService.java
+++ b/src/main/java/terra/backend/domain/cpu/service/CpuService.java
@@ -1,0 +1,15 @@
+package terra.backend.domain.cpu.service;
+
+import java.util.List;
+import terra.backend.domain.cpu.cache.dto.CpuUsage;
+import terra.backend.domain.cpu.entity.CpuDailyUsage;
+import terra.backend.domain.cpu.entity.CpuHourlyUsage;
+import terra.backend.domain.cpu.entity.CpuMinuteUsage;
+
+public interface CpuService {
+  CpuMinuteUsage save(int cpuLoad);
+
+  List<CpuHourlyUsage> saveHourlyUsage(List<CpuUsage> list);
+
+  CpuDailyUsage saveDailyUsage(List<CpuHourlyUsage> cpuHourlyUsages);
+}

--- a/src/main/java/terra/backend/domain/cpu/service/CpuServiceImpl.java
+++ b/src/main/java/terra/backend/domain/cpu/service/CpuServiceImpl.java
@@ -1,0 +1,71 @@
+package terra.backend.domain.cpu.service;
+
+import static terra.backend.common.utils.DateUtils.getCustomHour;
+
+import java.time.LocalDate;
+import java.util.IntSummaryStatistics;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import terra.backend.common.utils.IntSummaryStatisticsUtils;
+import terra.backend.domain.cpu.cache.dto.CpuUsage;
+import terra.backend.domain.cpu.entity.CpuDailyUsage;
+import terra.backend.domain.cpu.entity.CpuHourlyUsage;
+import terra.backend.domain.cpu.entity.CpuMinuteUsage;
+import terra.backend.domain.cpu.repository.DailyUsageRepository;
+import terra.backend.domain.cpu.repository.HourlyUsageRepository;
+import terra.backend.domain.cpu.repository.MinuteUsageRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CpuServiceImpl implements CpuService {
+  private final DailyUsageRepository dailyUsageRepository;
+  private final MinuteUsageRepository minuteUsageRepository;
+  private final HourlyUsageRepository hourlyUsageRepository;
+
+  @Override
+  @Transactional
+  public CpuMinuteUsage save(int cpuLoad) {
+    return minuteUsageRepository.save(new CpuMinuteUsage(cpuLoad));
+  }
+
+  @Override
+  @Transactional
+  public List<CpuHourlyUsage> saveHourlyUsage(List<CpuUsage> list) {
+    Map<Integer, IntSummaryStatistics> mapByHour = groupCpuUsageByHour(list);
+    List<CpuHourlyUsage> cpuHourlyUsages = transToCpuHourUsageList(mapByHour);
+    hourlyUsageRepository.saveAll(cpuHourlyUsages);
+    return cpuHourlyUsages;
+  }
+
+  @Override
+  @Transactional
+  public CpuDailyUsage saveDailyUsage(List<CpuHourlyUsage> list) {
+    CpuDailyUsage cpuDailyUsage = transToCpuDailyUsage(list);
+    return dailyUsageRepository.save(cpuDailyUsage);
+  }
+
+  private List<CpuHourlyUsage> transToCpuHourUsageList(
+      Map<Integer, IntSummaryStatistics> mapByHour) {
+    return mapByHour.entrySet().stream()
+        .map(entry -> new CpuHourlyUsage(entry.getValue(), getCustomHour(entry.getKey())))
+        .toList();
+  }
+
+  private Map<Integer, IntSummaryStatistics> groupCpuUsageByHour(List<CpuUsage> list) {
+    return list.stream()
+        .collect(
+            Collectors.groupingBy(
+                CpuUsage::getHour, Collectors.summarizingInt(CpuUsage::getUsage)));
+  }
+
+  private CpuDailyUsage transToCpuDailyUsage(List<CpuHourlyUsage> list) {
+    IntSummaryStatistics summary = IntSummaryStatisticsUtils.of(list);
+    return new CpuDailyUsage(
+        summary.getMax(), summary.getMin(), summary.getAverage(), LocalDate.now());
+  }
+}

--- a/src/main/java/terra/backend/domain/cpu/service/CpuServiceImpl.java
+++ b/src/main/java/terra/backend/domain/cpu/service/CpuServiceImpl.java
@@ -29,7 +29,7 @@ public class CpuServiceImpl implements CpuService {
 
   @Override
   @Transactional
-  public CpuMinuteUsage save(int cpuLoad) {
+  public CpuMinuteUsage saveMinuteUsage(int cpuLoad) {
     return minuteUsageRepository.save(new CpuMinuteUsage(cpuLoad));
   }
 

--- a/src/test/java/terra/backend/common/utils/DateUtilsTest.java
+++ b/src/test/java/terra/backend/common/utils/DateUtilsTest.java
@@ -1,0 +1,20 @@
+package terra.backend.common.utils;
+
+import java.time.LocalDateTime;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DateUtilsTest {
+
+  @Test
+  @DisplayName("hour정보를 제공했을 때 다른 정보를 제외한 hour 데이터가 내가 설정한 데이터가 맞는지 확인하는 테스트")
+  void createLocalDateTimeWithCustomHourTest() throws Exception {
+    // given
+    int hour = 10;
+    // when
+    LocalDateTime result = DateUtils.getCustomHour(hour);
+    // then
+    Assertions.assertThat(result.getHour()).isEqualTo(hour);
+  }
+}

--- a/src/test/java/terra/backend/common/utils/IntSummaryStatisticsUtilsTest.java
+++ b/src/test/java/terra/backend/common/utils/IntSummaryStatisticsUtilsTest.java
@@ -1,0 +1,36 @@
+package terra.backend.common.utils;
+
+import java.time.LocalDateTime;
+import java.util.IntSummaryStatistics;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import terra.backend.domain.cpu.entity.CpuHourlyUsage;
+
+class IntSummaryStatisticsUtilsTest {
+  @Test
+  @DisplayName("IntSummaryStatics 생성 메서드 테스트")
+  void createIntSummaryStaticsByListTest() throws Exception {
+    // given
+    List<CpuHourlyUsage> cpuHourlyUsages =
+        List.of(
+            new CpuHourlyUsage(100, 10, 10.0, 1000, 10, LocalDateTime.now()),
+            new CpuHourlyUsage(10, 5, 30.0, 400, 10, LocalDateTime.now()),
+            new CpuHourlyUsage(50, 2, 20.0, 100, 4, LocalDateTime.now()));
+    int maxExpect = cpuHourlyUsages.stream().mapToInt(CpuHourlyUsage::getMaxUsage).max().getAsInt();
+    int minExpect = cpuHourlyUsages.stream().mapToInt(CpuHourlyUsage::getMinUsage).min().getAsInt();
+    int count = cpuHourlyUsages.stream().mapToInt(CpuHourlyUsage::getSamplingCount).sum();
+    int sum = cpuHourlyUsages.stream().mapToInt(CpuHourlyUsage::getTotalUsage).sum();
+    String avgExpect = String.valueOf((double) sum / count);
+    // when
+    IntSummaryStatistics result = IntSummaryStatisticsUtils.of(cpuHourlyUsages);
+
+    // then
+    Assertions.assertThat(String.valueOf(result.getAverage())).isEqualTo(avgExpect);
+    Assertions.assertThat(result.getMax()).isEqualTo(maxExpect);
+    Assertions.assertThat(result.getMin()).isEqualTo(minExpect);
+    Assertions.assertThat(result.getCount()).isEqualTo(count);
+    Assertions.assertThat(result.getSum()).isEqualTo(sum);
+  }
+}

--- a/src/test/java/terra/backend/domain/cpu/repository/DailyUsageRepositoryTest.java
+++ b/src/test/java/terra/backend/domain/cpu/repository/DailyUsageRepositoryTest.java
@@ -1,0 +1,42 @@
+package terra.backend.domain.cpu.repository;
+
+import java.time.LocalDate;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import terra.backend.common.exception.exception.BusinessLogicException;
+import terra.backend.domain.cpu.entity.CpuDailyUsage;
+import terra.backend.domain.cpu.exception.CpuExceptionCode;
+
+@DataJpaTest
+class DailyUsageRepositoryTest {
+  @Autowired DailyUsageRepository repository;
+
+  @Test
+  @DisplayName("save() 테스트")
+  void saveTest() throws Exception {
+    // given
+    CpuDailyUsage requestEntity = new CpuDailyUsage(70, 20, 25.5, LocalDate.now());
+    // when
+    CpuDailyUsage result = repository.save(requestEntity);
+    // then
+    CpuDailyUsage expect =
+        repository
+            .findById(result.getId())
+            .orElseThrow(() -> new BusinessLogicException(CpuExceptionCode.NOT_FOUND));
+
+    Assertions.assertThat(result.getId()).isNotNull();
+    Assertions.assertThat(result).isEqualTo(expect);
+    Assertions.assertThat(result.getMaxUsage())
+        .isEqualTo(expect.getMaxUsage())
+        .isEqualTo(requestEntity.getMaxUsage());
+    Assertions.assertThat(result.getMinUsage())
+        .isEqualTo(expect.getMinUsage())
+        .isEqualTo(requestEntity.getMinUsage());
+    Assertions.assertThat(result.getAvgUsage())
+        .isEqualTo(expect.getAvgUsage())
+        .isEqualTo(requestEntity.getAvgUsage());
+  }
+}

--- a/src/test/java/terra/backend/domain/cpu/repository/HourlyUsageRepositoryTest.java
+++ b/src/test/java/terra/backend/domain/cpu/repository/HourlyUsageRepositoryTest.java
@@ -1,0 +1,44 @@
+package terra.backend.domain.cpu.repository;
+
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import terra.backend.common.exception.exception.BusinessLogicException;
+import terra.backend.common.utils.DateUtils;
+import terra.backend.domain.cpu.entity.CpuHourlyUsage;
+import terra.backend.domain.cpu.exception.CpuExceptionCode;
+
+@DataJpaTest
+class HourlyUsageRepositoryTest {
+  @Autowired HourlyUsageRepository repository;
+
+  @Test
+  @DisplayName("saveAll() 메서드 테스트")
+  void saveAllTest() {
+    // given
+    List<CpuHourlyUsage> requestEntityList =
+        List.of(
+            new CpuHourlyUsage(49, 10, 24.5, 100, 4, DateUtils.getCustomHour(1)),
+            new CpuHourlyUsage(67, 50, 25.5, 200, 10, DateUtils.getCustomHour(2)),
+            new CpuHourlyUsage(23, 20, 20.5, 200, 60, DateUtils.getCustomHour(3)),
+            new CpuHourlyUsage(57, 30, 30.5, 300, 60, DateUtils.getCustomHour(4)));
+    // when
+    List<CpuHourlyUsage> result = repository.saveAll(requestEntityList);
+
+    // then
+
+    Assertions.assertThat(result)
+        .hasSize(requestEntityList.size())
+        .allSatisfy(
+            entity -> {
+              CpuHourlyUsage expect =
+                  repository
+                      .findById(entity.getId())
+                      .orElseThrow(() -> new BusinessLogicException(CpuExceptionCode.NOT_FOUND));
+              Assertions.assertThat(entity).isEqualTo(expect);
+            });
+  }
+}

--- a/src/test/java/terra/backend/domain/cpu/repository/MinuteUsageRepositoryTest.java
+++ b/src/test/java/terra/backend/domain/cpu/repository/MinuteUsageRepositoryTest.java
@@ -1,0 +1,79 @@
+package terra.backend.domain.cpu.repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import terra.backend.domain.cpu.entity.CpuMinuteUsage;
+
+@DataJpaTest
+class MinuteUsageRepositoryTest {
+  @Autowired MinuteUsageRepository repository;
+
+  @Test
+  @DisplayName("save() 메서드 테스트")
+  void saveTest() {
+    // given
+    CpuMinuteUsage requestEntity = new CpuMinuteUsage(20);
+    // when
+    CpuMinuteUsage result = repository.save(requestEntity);
+
+    // then
+    Assertions.assertThat(result).isNotNull();
+    Assertions.assertThat(result)
+        .extracting(
+            CpuMinuteUsage::getId, CpuMinuteUsage::getUsage, CpuMinuteUsage::getSamplingDate)
+        .containsExactly(result.getId(), requestEntity.getUsage(), requestEntity.getSamplingDate());
+  }
+
+  @Test
+  @DisplayName("findTodayUsage() 메서드 테스트")
+  void findTodayUsageTest() throws Exception {
+    // given
+    List<CpuMinuteUsage> saveEntity =
+        List.of(
+            new CpuMinuteUsage(20),
+            new CpuMinuteUsage(30),
+            new CpuMinuteUsage(22),
+            new CpuMinuteUsage(23),
+            new CpuMinuteUsage(42),
+            new CpuMinuteUsage(22));
+    // when
+    repository.saveAll(saveEntity);
+
+    List<CpuMinuteUsage> result =
+        repository.findTodayUsage(LocalDateTime.of(LocalDate.now(), LocalTime.of(0, 0)));
+    // then
+    Assertions.assertThat(result)
+        .hasSize(saveEntity.size())
+        .extracting(CpuMinuteUsage::getUsage)
+        .containsExactlyInAnyOrderElementsOf(
+            saveEntity.stream().map(CpuMinuteUsage::getUsage).toList());
+  }
+
+  @Test
+  @DisplayName("findTodayUsage() 메서드 테스트 : 오늘 저장된 데이터가 존재 하지 않을 때")
+  void findTodayUsageFindFailTest() throws Exception {
+    // given
+    List<CpuMinuteUsage> saveEntity =
+        List.of(
+            new CpuMinuteUsage(20, LocalDateTime.of(2022, 12, 3, 12, 1)),
+            new CpuMinuteUsage(30, LocalDateTime.of(2022, 12, 3, 12, 2)),
+            new CpuMinuteUsage(22, LocalDateTime.of(2022, 12, 3, 12, 3)),
+            new CpuMinuteUsage(23, LocalDateTime.of(2022, 12, 3, 12, 4)),
+            new CpuMinuteUsage(42, LocalDateTime.of(2022, 12, 3, 12, 5)),
+            new CpuMinuteUsage(22, LocalDateTime.of(2022, 12, 3, 12, 6)));
+    // when
+    repository.saveAll(saveEntity);
+
+    List<CpuMinuteUsage> result =
+        repository.findTodayUsage(LocalDateTime.of(LocalDate.now(), LocalTime.of(0, 0)));
+    // then
+    Assertions.assertThat(result).isEmpty();
+  }
+}

--- a/src/test/java/terra/backend/domain/cpu/scheduler/CpuSaveSchedulerTest.java
+++ b/src/test/java/terra/backend/domain/cpu/scheduler/CpuSaveSchedulerTest.java
@@ -1,0 +1,41 @@
+package terra.backend.domain.cpu.scheduler;
+
+import java.util.Random;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StopWatch;
+import terra.backend.domain.cpu.cache.CpuCache;
+import terra.backend.domain.cpu.entity.CpuMinuteUsage;
+
+@SpringBootTest
+@Transactional
+class CpuSaveSchedulerTest {
+  @Autowired CpuSaveScheduler scheduler;
+  @Autowired CpuCache cache;
+
+  @Test
+  @DisplayName("스케줄링한 Task가 30초 이내에 실행이 되는지 검증")
+  void saveDailyAndHourlyUsageTest() throws Exception {
+    int count = 24 * 60;
+    Random random = new Random();
+
+    // 20에서 80 사이의 임의의 정수 값 생성
+
+    for (int i = 1; i <= count; i++) {
+      cache.save(new CpuMinuteUsage(random.nextInt(61) + 20));
+    }
+
+    StopWatch stopWatch = new StopWatch();
+    stopWatch.start();
+    scheduler.saveDailyAndHourlyUsage();
+    stopWatch.stop();
+
+    double runningTime = stopWatch.getTotalTimeSeconds();
+    System.out.println(stopWatch.prettyPrint());
+    Assertions.assertThat(runningTime).isLessThan(30.0);
+  }
+}

--- a/src/test/java/terra/backend/domain/cpu/service/CpuServiceImplTest.java
+++ b/src/test/java/terra/backend/domain/cpu/service/CpuServiceImplTest.java
@@ -33,20 +33,26 @@ class CpuServiceImplTest {
   @DisplayName("단위 분 당 CPU 사용량 저장 save() 테스트")
   void saveMinuteUsageTest() throws Exception {
     // given
-    ArgumentCaptor<CpuMinuteUsage> returnRepositoryCaptor = ArgumentCaptor.forClass(CpuMinuteUsage.class);
-    ArgumentCaptor<CpuMinuteUsage> sendRepositoryCaptor = ArgumentCaptor.forClass(CpuMinuteUsage.class);
+    ArgumentCaptor<CpuMinuteUsage> returnRepositoryCaptor =
+        ArgumentCaptor.forClass(CpuMinuteUsage.class);
+    ArgumentCaptor<CpuMinuteUsage> sendRepositoryCaptor =
+        ArgumentCaptor.forClass(CpuMinuteUsage.class);
     int cpuLoad = 10;
     CpuMinuteUsage savedEntity = new CpuMinuteUsage(cpuLoad);
 
-    BDDMockito.given(minuteUsageRepository.save(sendRepositoryCaptor.capture())).willReturn(savedEntity);
+    BDDMockito.given(minuteUsageRepository.save(sendRepositoryCaptor.capture()))
+        .willReturn(savedEntity);
     // when
     service.saveMinuteUsage(cpuLoad);
     // then
     Mockito.verify(minuteUsageRepository, Mockito.times(1)).save(returnRepositoryCaptor.capture());
 
-    Assertions.assertThat(returnRepositoryCaptor.getValue().getUsage()).isEqualTo(savedEntity.getUsage());
-    Assertions.assertThat(returnRepositoryCaptor.getValue().getUsage()).isEqualTo(sendRepositoryCaptor.getValue().getUsage());
-    Assertions.assertThat(sendRepositoryCaptor.getValue().getUsage()).isEqualTo(savedEntity.getUsage());
+    Assertions.assertThat(returnRepositoryCaptor.getValue().getUsage())
+        .isEqualTo(savedEntity.getUsage());
+    Assertions.assertThat(returnRepositoryCaptor.getValue().getUsage())
+        .isEqualTo(sendRepositoryCaptor.getValue().getUsage());
+    Assertions.assertThat(sendRepositoryCaptor.getValue().getUsage())
+        .isEqualTo(savedEntity.getUsage());
   }
 
   @Test
@@ -64,7 +70,8 @@ class CpuServiceImplTest {
     ArgumentCaptor<List<CpuHourlyUsage>> sendRepositoryCaptor = ArgumentCaptor.forClass(List.class);
     // given
 
-    BDDMockito.given(hourlyUsageRepository.saveAll(sendRepositoryCaptor.capture())).willReturn(mockSave);
+    BDDMockito.given(hourlyUsageRepository.saveAll(sendRepositoryCaptor.capture()))
+        .willReturn(mockSave);
     // when
     service.saveHourlyUsage(parameter);
     // then
@@ -74,29 +81,31 @@ class CpuServiceImplTest {
 
     Assertions.assertThat(result).hasSameSizeAs(mockSave);
     Assertions.assertThat(result.get(0)).usingRecursiveComparison().isEqualTo(mockSave.get(0));
-
   }
 
   @Test
   @DisplayName("단위 시간 당 CPU 사용량 저장 saveHourly() 테스트")
   void saveDailyUsageTest() throws Exception {
     // given
-    ArgumentCaptor<CpuDailyUsage> sendRepositoryCaptor = ArgumentCaptor.forClass(CpuDailyUsage.class);
-    ArgumentCaptor<CpuDailyUsage> returnRepositoryCaptor = ArgumentCaptor.forClass(CpuDailyUsage.class);
-    List<CpuHourlyUsage> parameter = List.of(
-        new CpuHourlyUsage(40, 10, 25.0, 100, 4, DateUtils.getCustomHour(1)),
-        new CpuHourlyUsage(50, 10, 25.0, 200, 10, DateUtils.getCustomHour(2)),
-        new CpuHourlyUsage(60, 5, 25.0, 300, 20, DateUtils.getCustomHour(3))
-    );
+    ArgumentCaptor<CpuDailyUsage> sendRepositoryCaptor =
+        ArgumentCaptor.forClass(CpuDailyUsage.class);
+    ArgumentCaptor<CpuDailyUsage> returnRepositoryCaptor =
+        ArgumentCaptor.forClass(CpuDailyUsage.class);
+    List<CpuHourlyUsage> parameter =
+        List.of(
+            new CpuHourlyUsage(40, 10, 25.0, 100, 4, DateUtils.getCustomHour(1)),
+            new CpuHourlyUsage(50, 10, 25.0, 200, 10, DateUtils.getCustomHour(2)),
+            new CpuHourlyUsage(60, 5, 25.0, 300, 20, DateUtils.getCustomHour(3)));
 
     int expectedMax = parameter.stream().mapToInt(CpuHourlyUsage::getMaxUsage).max().getAsInt();
     int expectedMin = parameter.stream().mapToInt(CpuHourlyUsage::getMinUsage).min().getAsInt();
     int expectedCount = parameter.stream().mapToInt(CpuHourlyUsage::getSamplingCount).sum();
     int expectedTotal = parameter.stream().mapToInt(CpuHourlyUsage::getTotalUsage).sum();
-    double avg = ((double)expectedTotal/expectedCount);
+    double avg = ((double) expectedTotal / expectedCount);
 
     CpuDailyUsage saveMock = new CpuDailyUsage(expectedMax, expectedMin, avg, LocalDate.now());
-    BDDMockito.given(dailyUsageRepository.save(sendRepositoryCaptor.capture())).willReturn(saveMock);
+    BDDMockito.given(dailyUsageRepository.save(sendRepositoryCaptor.capture()))
+        .willReturn(saveMock);
     // when
     service.saveDailyUsage(parameter);
     // then

--- a/src/test/java/terra/backend/domain/cpu/service/CpuServiceImplTest.java
+++ b/src/test/java/terra/backend/domain/cpu/service/CpuServiceImplTest.java
@@ -1,0 +1,107 @@
+package terra.backend.domain.cpu.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import terra.backend.common.utils.DateUtils;
+import terra.backend.domain.cpu.cache.dto.CpuUsage;
+import terra.backend.domain.cpu.entity.CpuDailyUsage;
+import terra.backend.domain.cpu.entity.CpuHourlyUsage;
+import terra.backend.domain.cpu.entity.CpuMinuteUsage;
+import terra.backend.domain.cpu.repository.DailyUsageRepository;
+import terra.backend.domain.cpu.repository.HourlyUsageRepository;
+import terra.backend.domain.cpu.repository.MinuteUsageRepository;
+
+@ExtendWith(MockitoExtension.class)
+class CpuServiceImplTest {
+  @Mock DailyUsageRepository dailyUsageRepository;
+  @Mock MinuteUsageRepository minuteUsageRepository;
+  @Mock HourlyUsageRepository hourlyUsageRepository;
+  @InjectMocks CpuServiceImpl service;
+
+  @Test
+  @DisplayName("단위 분 당 CPU 사용량 저장 save() 테스트")
+  void saveMinuteUsageTest() throws Exception {
+    // given
+    ArgumentCaptor<CpuMinuteUsage> returnRepositoryCaptor = ArgumentCaptor.forClass(CpuMinuteUsage.class);
+    ArgumentCaptor<CpuMinuteUsage> sendRepositoryCaptor = ArgumentCaptor.forClass(CpuMinuteUsage.class);
+    int cpuLoad = 10;
+    CpuMinuteUsage savedEntity = new CpuMinuteUsage(cpuLoad);
+
+    BDDMockito.given(minuteUsageRepository.save(sendRepositoryCaptor.capture())).willReturn(savedEntity);
+    // when
+    service.saveMinuteUsage(cpuLoad);
+    // then
+    Mockito.verify(minuteUsageRepository, Mockito.times(1)).save(returnRepositoryCaptor.capture());
+
+    Assertions.assertThat(returnRepositoryCaptor.getValue().getUsage()).isEqualTo(savedEntity.getUsage());
+    Assertions.assertThat(returnRepositoryCaptor.getValue().getUsage()).isEqualTo(sendRepositoryCaptor.getValue().getUsage());
+    Assertions.assertThat(sendRepositoryCaptor.getValue().getUsage()).isEqualTo(savedEntity.getUsage());
+  }
+
+  @Test
+  @DisplayName("단위 시간 당 CPU 사용량 저장 saveHourly() 테스트")
+  void saveHourlyUsageTest() throws Exception {
+    List<CpuUsage> parameter =
+        List.of(
+            new CpuUsage(10, LocalDateTime.of(2024, 05, 23, 1, 1)),
+            new CpuUsage(20, LocalDateTime.of(2024, 05, 23, 1, 2)),
+            new CpuUsage(30, LocalDateTime.of(2024, 05, 23, 1, 3)),
+            new CpuUsage(40, LocalDateTime.of(2024, 05, 23, 1, 4)));
+    List<CpuHourlyUsage> mockSave =
+        List.of(new CpuHourlyUsage(40, 10, 25.0, 100, 4, DateUtils.getCustomHour(1)));
+
+    ArgumentCaptor<List<CpuHourlyUsage>> sendRepositoryCaptor = ArgumentCaptor.forClass(List.class);
+    // given
+
+    BDDMockito.given(hourlyUsageRepository.saveAll(sendRepositoryCaptor.capture())).willReturn(mockSave);
+    // when
+    service.saveHourlyUsage(parameter);
+    // then
+    List<CpuHourlyUsage> result = sendRepositoryCaptor.getValue();
+
+    Mockito.verify(hourlyUsageRepository, Mockito.times(1)).saveAll(Mockito.anyList());
+
+    Assertions.assertThat(result).hasSameSizeAs(mockSave);
+    Assertions.assertThat(result.get(0)).usingRecursiveComparison().isEqualTo(mockSave.get(0));
+
+  }
+
+  @Test
+  @DisplayName("단위 시간 당 CPU 사용량 저장 saveHourly() 테스트")
+  void saveDailyUsageTest() throws Exception {
+    // given
+    ArgumentCaptor<CpuDailyUsage> sendRepositoryCaptor = ArgumentCaptor.forClass(CpuDailyUsage.class);
+    ArgumentCaptor<CpuDailyUsage> returnRepositoryCaptor = ArgumentCaptor.forClass(CpuDailyUsage.class);
+    List<CpuHourlyUsage> parameter = List.of(
+        new CpuHourlyUsage(40, 10, 25.0, 100, 4, DateUtils.getCustomHour(1)),
+        new CpuHourlyUsage(50, 10, 25.0, 200, 10, DateUtils.getCustomHour(2)),
+        new CpuHourlyUsage(60, 5, 25.0, 300, 20, DateUtils.getCustomHour(3))
+    );
+
+    int expectedMax = parameter.stream().mapToInt(CpuHourlyUsage::getMaxUsage).max().getAsInt();
+    int expectedMin = parameter.stream().mapToInt(CpuHourlyUsage::getMinUsage).min().getAsInt();
+    int expectedCount = parameter.stream().mapToInt(CpuHourlyUsage::getSamplingCount).sum();
+    int expectedTotal = parameter.stream().mapToInt(CpuHourlyUsage::getTotalUsage).sum();
+    double avg = ((double)expectedTotal/expectedCount);
+
+    CpuDailyUsage saveMock = new CpuDailyUsage(expectedMax, expectedMin, avg, LocalDate.now());
+    BDDMockito.given(dailyUsageRepository.save(sendRepositoryCaptor.capture())).willReturn(saveMock);
+    // when
+    service.saveDailyUsage(parameter);
+    // then
+    CpuDailyUsage result = sendRepositoryCaptor.getValue();
+    Mockito.verify(dailyUsageRepository, Mockito.times(1)).save(returnRepositoryCaptor.capture());
+    Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(saveMock);
+  }
+}


### PR DESCRIPTION
## What is this PR

- 스케줄러를 활용해 분당 CPU 사용량 측정 기능 구현 완료에 따른 머지

## Changes

- In-Memory Cache를 활용해 자정에 시간 / 일별 CPU 데이터 한번에 저장

## In-Memory 저장 후 한번에 Insert 이유
1. 매 시간마다 RDB에서 분당 데이터를 꺼내 집계 후 이를 가공하는 것 보다 In-Memory에 저장한 뒤 한번에 처리하는 것이 효율적이라고 판단
    - 서버가 중단 될 가능성이 존재하기 때문에 서버 실행 시 해당 데이터를 로딩해야됨
## Issue Number

fix #3 

resolve #3 

close #3 